### PR TITLE
Bug fix/2

### DIFF
--- a/battle-gui/pom.xml
+++ b/battle-gui/pom.xml
@@ -57,5 +57,10 @@
             <artifactId>javafx-graphics</artifactId>
             <version>11-ea+25</version>
         </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-swing</artifactId>
+            <version>11-ea+25</version>
+        </dependency>
     </dependencies>
 </project>

--- a/battle-gui/src/main/java/pl/psi/gui/MainBattleController.java
+++ b/battle-gui/src/main/java/pl/psi/gui/MainBattleController.java
@@ -172,21 +172,32 @@ public class MainBattleController implements PropertyChangeListener {
                 final MapTile mapTile = new MapTile("");
 
                 if (gameEngine.canMove(new Point(x1, y1)) && !gameEngine.isHeroCastingSpell()) {
-                    mapTile.setBackground(Color.DARKGREY);
+                    if (!gameEngine.getField(new Point(x1, y1)).isEmpty()){
+                        mapTile.setBackground(new Image(gameEngine.getField(new Point(x1, y1)).get().getImagePath()),java.awt.Color.LIGHT_GRAY);
+                    }else{
+                        mapTile.setBackground(Color.DARKGREY);
+                    }
                     List<Point> path = gameEngine.getPath(new Point(x1, y1));
 
                     if (gameEngine.getCreature(new Point(x1, y1)).isEmpty() || gameEngine.getCreature(new Point(x1, y1)).isPresent()) {
                         mapTile.setOnMouseEntered(mouseEvent -> {
                             if (gameEngine.getCreature(new Point(x1, y1)).isEmpty()) {
-                                mapTile.setBackground(Color.GREY);
+                                if (!gameEngine.getField(new Point(x1, y1)).isEmpty()){
+                                    mapTile.setBackground(new Image(gameEngine.getField(new Point(x1, y1)).get().getImagePath()),java.awt.Color.GRAY);
+                                }else{
+                                    mapTile.setBackground(Color.GREY);
+                                }
+
                             }
                         });
 
                         mapTile.setOnMouseExited(mouseEvent -> {
                             if (gameEngine.getCreature(new Point(x1, y1)).isEmpty()) {
-                                mapTile.setBackground(Color.DARKGREY);
-                                gameEngine.getField(new Point(x1, y1))
-                                    .ifPresent(f -> mapTile.setBackground(new Image(f.getImagePath())));
+                                if (!gameEngine.getField(new Point(x1, y1)).isEmpty()){
+                                    mapTile.setBackground(new Image(gameEngine.getField(new Point(x1, y1)).get().getImagePath()),java.awt.Color.LIGHT_GRAY);
+                                }else{
+                                    mapTile.setBackground(Color.DARKGREY);
+                                }
                             }
                         });
                     }
@@ -202,11 +213,10 @@ public class MainBattleController implements PropertyChangeListener {
                                     });
                                 }
                             });
+                } else if (!gameEngine.getField(new Point(x1, y1)).isEmpty()){
+                    mapTile.setBackground(new Image(gameEngine.getField(new Point(x1, y1)).get().getImagePath()),java.awt.Color.WHITE);
                 }
-                if (gameEngine.getField(new Point(x1,y1)).isPresent()){
-                    Image img = new Image(gameEngine.getField(new Point(x1, y1)).get().getImagePath());
-                    mapTile.setBackground(img);
-                }
+
                 if (gameEngine.getCreature(new Point(x1, y1)).isPresent()) {
                     if (gameEngine.getCreature(new Point(x, y)).get().isAlive()) {
                         mapTile.setName("\n\n" + gameEngine.getCreature(new Point(x, y)).get().getAmount());

--- a/battle-gui/src/main/java/pl/psi/gui/MainBattleController.java
+++ b/battle-gui/src/main/java/pl/psi/gui/MainBattleController.java
@@ -203,7 +203,10 @@ public class MainBattleController implements PropertyChangeListener {
                                 }
                             });
                 }
-
+                if (gameEngine.getField(new Point(x1,y1)).isPresent()){
+                    Image img = new Image(gameEngine.getField(new Point(x1, y1)).get().getImagePath());
+                    mapTile.setBackground(img);
+                }
                 if (gameEngine.getCreature(new Point(x1, y1)).isPresent()) {
                     if (gameEngine.getCreature(new Point(x, y)).get().isAlive()) {
                         mapTile.setName("\n\n" + gameEngine.getCreature(new Point(x, y)).get().getAmount());

--- a/battle-gui/src/main/java/pl/psi/gui/MapTile.java
+++ b/battle-gui/src/main/java/pl/psi/gui/MapTile.java
@@ -1,6 +1,9 @@
 package pl.psi.gui;
 
+import javafx.embed.swing.SwingFXUtils;
 import javafx.scene.image.Image;
+import javafx.scene.image.PixelWriter;
+import javafx.scene.image.WritableImage;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.ImagePattern;
@@ -8,6 +11,8 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
 import javafx.scene.text.Text;
+
+import java.awt.image.BufferedImage;
 
 class MapTile extends StackPane {
 
@@ -36,6 +41,46 @@ class MapTile extends StackPane {
 
     void setBackground(final Image img) {
         rect.setFill(new ImagePattern(img));
+    }
+
+    /**
+     * Prepares and sets background for MapTile with ARGB format image
+     * For backgrounds without alpha channels please use other setBackground methods since this particular one is significantly slower due to manual pixel writing
+     * @param img ARGB image
+     * @param bgcolor background color for pixels with complete transparency
+     */
+    void setBackground(final Image img, java.awt.Color bgcolor){
+
+
+        BufferedImage image = new BufferedImage((int)img.getWidth(), (int)img.getHeight(), BufferedImage.TYPE_INT_RGB);
+        WritableImage write = new WritableImage(image.getWidth(), image.getHeight());
+        PixelWriter writepixel = write.getPixelWriter();
+        for (int h = 0; h < image.getHeight(); h++) {
+            for (int w = 0; w < image.getWidth(); w++) {
+                if (img.getPixelReader().getArgb(w, h)==0){
+                    writepixel.setArgb(w, h, bgcolor.getRGB());
+                }else{
+                    writepixel.setArgb(w, h, img.getPixelReader().getArgb(w, h));
+                }
+            }
+
+        }
+
+        for (int i = 0; i < (int)img.getHeight(); i++){
+            for (int k = 0; k < (int)img.getWidth(); k++){
+                image.setRGB(k, i, img.getPixelReader().getArgb(k, i));
+            }
+        }
+        BufferedImage result = new BufferedImage(
+                image.getWidth(),
+                image.getHeight(),
+                BufferedImage.TYPE_INT_ARGB);
+
+
+        //Image img = new Image(gameEngine.getField(new Point(x1, y1)).get().getImagePath());
+
+        Image imgr = SwingFXUtils.toFXImage(result, null);
+        rect.setFill(new ImagePattern(write));
     }
 
 }


### PR DESCRIPTION
# Fixed the bug preventing special fields from rendering until they get hovered

## Notes
The bug was caused by rendering in wrong order, however, fixing it unveiled another problem. The issue masked by the bug was caused by incorrectly rendering png files by `setFill()` method from Rectangle scope, by how i understand it `setFill()` is ment to be used as strictly background rendering means, so when we used it expecting it to switch the render or layer images (`canMove` indicator fields under special fields) it simply rendered it incorrectly leaving unit icon under the special field even after it was moved elsewhere. It was fixed by completely changing the way Image is generated, instead of simply loading it from source, it now uses separate method @ `MapTile#setBackground(final Image img, java.awt.Color bgcolor)`  which paints the image from the Image argument on top of selected color (note that its a `java.awt.Color` collection), it simply replaces spaces with complete transparency with the color, and then fills it using `setFill()`

## additional dependencies
- javafx-swing (for BufferedImage manipulation)